### PR TITLE
La footpod-kalibrering ta inn runder i URLen.

### DIFF
--- a/src/intro/kalibrer-footpod.md
+++ b/src/intro/kalibrer-footpod.md
@@ -34,6 +34,12 @@
     }
   }, { deep: true })
 
+  // Prefill intervals if given in the URL
+  if (window.location.hash !== undefined) {
+    const rounds = window.location.hash.substr(1).split(',').map(x => parseFloat(x));
+    intervaller.value = rounds.map(x => { return { meter: x, rounds: computeRounds(x) }});
+  }
+
   const kalibreringsVerdier = computed(() => {
     const meterSum = intervaller.value.reduce((acc, interval) => {
       const meter = parseFloat(interval.meter);


### PR DESCRIPTION
Dette er ment for autokalibrering basert på data fra skvidar.run, slik at man kan klikke på en gitt økt der og automatisk få over rundedataene (se egen PR).